### PR TITLE
Add a flag for readonly devices.

### DIFF
--- a/BlockDevices/API.txt
+++ b/BlockDevices/API.txt
@@ -1,7 +1,8 @@
 Device information block
 
 +0  device_flags:
-        None defined
+        b0:     Device is read only
+        b1-31:  Must be 0
 +4  Interface and media type
         b0-15:  Interface type
                     0 = Unknown
@@ -77,6 +78,9 @@ SWI BlockDevices_Write
 
 Writes data to the block device.
 
+Errors:
+    ReadOnly: Reported when the device is not writeable.
+
 
 SWI BlockDevices_Register
 
@@ -90,6 +94,7 @@ Register a block device driver.
 
 Errors:
     RegisterFailed: Reported when the device is not recognised.
+    RegisterFailedFlags: Reported when the flags supplied are not recognised.
 
 
 SWI BlockDevices_Deregister

--- a/BlockDevices/Makefile,fe1
+++ b/BlockDevices/Makefile,fe1
@@ -2,6 +2,8 @@
 # Makefile for BlockDevices
 #
 
+BUILD32 = 1
+
 #
 # Program specific options:
 #
@@ -56,6 +58,7 @@ include CModule
 # Additional dependencies
 $(OZDIR).module: h.modhead
 $(OZDIR).commands: h.modhead
+$(OZDIR).device: h.modhead
 
 # Export rules
 # For any files you export with EXPORTS you may need to include an

--- a/BlockDevices/c/device
+++ b/BlockDevices/c/device
@@ -10,7 +10,8 @@
 #include "callx.h"
 #include "fortify.h"
 
-/* #include "BlockDevices.h" */
+#include "modhead.h"
+#include "BlockDevices.h"
 #include "device.h"
 #include "str.h"
 
@@ -94,6 +95,9 @@ _kernel_oserror * device_read(device_t *device, unsigned long flags, transfer_bl
  ******************************************************************/
 _kernel_oserror * device_write(device_t *device, unsigned long flags, transfer_block_t *block)
 {
+    if (device->info.device_flags & DeviceFlag_ReadOnly)
+        return err_ReadOnly;
+
     return _callx(device->driver_code, device->driver_ws,
                  _INR(0, 3),
                  2, device->device_id, flags, block);

--- a/BlockDevices/c/module
+++ b/BlockDevices/c/module
@@ -251,6 +251,9 @@ _kernel_oserror *SWI_Register(int number, _kernel_swi_regs *r, void *pw)
 
     if (!running) return err_Starting;
 
+    if (info->device_flags & DeviceFlag_Valid)
+        return err_RegisterFailedFlags; /* They gave unsupported flags */
+
     dev = device_create(
         info, driver_code, driver_ws);
 

--- a/BlockDevices/cmhg/modhead
+++ b/BlockDevices/cmhg/modhead
@@ -46,7 +46,9 @@ error-identifiers: \
  err_InitFailed("Initalisation failed") \
  err_BadDevice("Bad device identifier to BlockDevices") \
  err_UnsupportedOperation("Unsupported operation") \
- err_RegisterFailed("Device registration failed")
+ err_RegisterFailed("Device registration failed") \
+ err_RegisterFailedFlags("Device registration failed (flags not supported)") \
+ err_ReadOnly("Device cannot be written to (device is read only)")
 
 ; When the module is initialised, this routine will be entered. You should
 ; be very careful to initialise your module safely. If anything fails, you

--- a/BlockDevices/h/BlockDevices
+++ b/BlockDevices/h/BlockDevices
@@ -20,6 +20,10 @@
 // Invalid device id
 #define DeviceId_Invalid (0)
 
+/* Flags understood in the device information block */
+#define DeviceFlag_ReadOnly (1<<0)      /* Device cannot be written to */
+#define DeviceFlag_Valid    (1<<0)      /* Mask of the valid device flags */
+
 // Block device info block
 typedef struct device_info_s {
     unsigned  device_flags;


### PR DESCRIPTION
Readonly devices can now be identified explicitly to make them clear to clients that they shouldn't try writing. Filesystems could mark all objects as read only if they knew that the device was protected in this way.

If a write operation is performed on a device which has been flagged as read only, an error is returned.

Unrecognised flags are now rejected as well.