### PR TITLE
Add checks for transfers outside of device.

### DIFF
--- a/BlockDevices/c/device
+++ b/BlockDevices/c/device
@@ -138,6 +138,31 @@ failed:
     return NULL;
 }
 
+/*************************************************** Gerph *********
+ Function:      device_check_transfer
+ Description:   Check whether a transfer would be valid
+ Parameters:    device-> the device we're operating on
+                transfer = the transfer address
+ Returns:       pointer to error to return, or NULL if operation is acceptable
+ ******************************************************************/
+_kernel_oserror *device_check_transfer(device_t *device, transfer_block_t *transfer)
+{
+    blockaddr_t transfer_end;
+    int blocks_count;
+    blockaddr_t blocks_count_ll;
+
+    blocks_count = (transfer->count + device->info.block_size - 1) / device->info.block_size;
+
+    LL_UI2L(blocks_count_ll, blocks_count);
+    LL_ADD(transfer_end, transfer->lba, blocks_count_ll);
+    if (LL_UCMP(transfer_end, >, device->info.block_count))
+    {
+        return err_TransferOutsideDevice;
+    }
+
+    return NULL;
+}
+
 /*******************************************************************
  Function:      device_destroy
  Description:   Destroy the device
@@ -175,6 +200,11 @@ void device_destroy(device_t *device)
  ******************************************************************/
 _kernel_oserror * device_read(device_t *device, unsigned long flags, transfer_block_t *block)
 {
+    _kernel_oserror *err;
+    err = device_check_transfer(device, block);
+    if (err)
+        return err;
+
     return _callx(device->driver_code, device->driver_ws,
                  _INR(0, 3),
                  1, device->device_id, flags, block);
@@ -192,8 +222,13 @@ _kernel_oserror * device_read(device_t *device, unsigned long flags, transfer_bl
  ******************************************************************/
 _kernel_oserror * device_write(device_t *device, unsigned long flags, transfer_block_t *block)
 {
+    _kernel_oserror *err;
     if (device->info.device_flags & DeviceFlag_ReadOnly)
         return err_ReadOnly;
+
+    err = device_check_transfer(device, block);
+    if (err)
+        return err;
 
     return _callx(device->driver_code, device->driver_ws,
                  _INR(0, 3),

--- a/BlockDevices/cmhg/modhead
+++ b/BlockDevices/cmhg/modhead
@@ -48,7 +48,8 @@ error-identifiers: \
  err_UnsupportedOperation("Unsupported operation") \
  err_RegisterFailed("Device registration failed") \
  err_RegisterFailedFlags("Device registration failed (flags not supported)") \
- err_ReadOnly("Device cannot be written to (device is read only)")
+ err_ReadOnly("Device cannot be written to (device is read only)") \
+ err_TransferOutsideDevice("Block transfer is beyond device end")
 
 ; When the module is initialised, this routine will be entered. You should
 ; be very careful to initialise your module safely. If anything fails, you

--- a/BlockDevices/h/BlockDevices
+++ b/BlockDevices/h/BlockDevices
@@ -12,7 +12,7 @@
 // longlong.h defines USE_LONG_LONG itself
 #undef USE_LONG_LONG
 #include "longlong.h"
-#define UINT64 longlong_t
+#define UINT64 ulonglong_t
 #else
 #define UINT64 uint64_t
 #endif
@@ -24,22 +24,25 @@
 #define DeviceFlag_ReadOnly (1<<0)      /* Device cannot be written to */
 #define DeviceFlag_Valid    (1<<0)      /* Mask of the valid device flags */
 
+// The address of a block on a device
+typedef UINT64 blockaddr_t;
+
 // Block device info block
 typedef struct device_info_s {
-    unsigned  device_flags;
-    unsigned  interface_type:16;
-    unsigned  media_type:16;
-    unsigned  parent_device;
-    unsigned  partition_scheme:8;
-    unsigned  partition_index:24;
-    unsigned  partition_type;
-    UINT64    block_count;
-    unsigned  block_size;
-    char *    name;
-    char *    manufacturer;
-    char *    product;
-    char *    serial;
-    char *    firmware;
+    unsigned    device_flags;
+    unsigned    interface_type:16;
+    unsigned    media_type:16;
+    unsigned    parent_device;
+    unsigned    partition_scheme:8;
+    unsigned    partition_index:24;
+    unsigned    partition_type;
+    blockaddr_t block_count;
+    unsigned    block_size;
+    char *      name;
+    char *      manufacturer;
+    char *      product;
+    char *      serial;
+    char *      firmware;
 } device_info_t;
 
 // Interface types
@@ -72,9 +75,9 @@ typedef enum partition_scheme_e {
 
 // Used to control read / writes
 typedef struct transfer_block_s {
-  UINT64   lba;
-  void *   address;
-  unsigned count;
+  blockaddr_t lba;
+  void *      address;
+  unsigned    count;
 } transfer_block_t;
 
 #endif


### PR DESCRIPTION
# Summary

If we attempt to perform a transfer which is beyond the device bounds, we should fault it in BlockDevices, not leave it to the devices to handle.

# Testing

Not tested. It compiled.
