### PR TITLE
Add CODEOWNERS files, issue and PR templates.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,29 @@
+---
+name: Bug report
+about: Something that's not right about the project
+title: ''
+labels: bug
+assignees: 'c-jo'
+
+---
+
+## Problem statement
+
+<!-- Explain what you think is wrong -->
+
+
+## Environment
+
+<!-- Give details about the environment in which you are running, for
+     example, the OS version, hardware, devices or applications that
+     are related to the issue -->
+
+
+## Expected result
+
+<!-- Explain what you expect to happen -->
+
+
+## Reproduction steps
+
+<!-- Explain how to reproduce, or which test the failure is in -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,30 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: enhancement
+assignees: 'c-jo'
+
+---
+
+## Is your feature request related to a problem?
+
+<!-- Give a clear description of what you're trying to address with
+     this request.
+     For example, "I'm always frustrated when [...]",
+     "It is hard to [...]"
+  -->
+
+## Describe the solution you'd like
+
+<!-- Give a clear description of how you the request might be
+     addressed. If you have ideas about how it could be implemented,
+     separate them from user interface changes.
+  -->
+
+## Additional context
+
+<!-- If you have some context, like places where this would have
+     helped, screenshots or mock ups of an interface, or the sort
+     of results you'd like to see, include them here.
+  -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,17 @@
+# Changes
+
+<!-- Describe the changes you've made in this section.
+     Try to explain why they're needed and what they do.
+     Your reviewers will use this to decide whether the
+     change is sufficient and correct.
+     You can include pictures or diagrams in here
+     (see mermaid documentation on GitHub).
+ -->
+
+# Testing
+
+<!-- Describe the testing you have done manually to
+     satisfy yourself that the change works as intended.
+     If automated tests have been updated, state this.
+     Include output or pictures if necessary.
+ -->

--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -1,0 +1,25 @@
+---
+# Automatically assign issues to users
+#
+# When new issues are created, they will automatically be assigned to a user.
+#
+
+name: Issue assignment
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  # See GitHub repository here: https://github.com/pozil/auto-assign-issue
+  auto-assign:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Auto-assign issue
+        uses: pozil/auto-assign-issue@v2
+        with:
+          assignees: c-jo
+          abortIfPreviousAssignees: true
+          allowSelfAssign: true

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,10 @@
+##
+# CODEOWNERS - define who is responsible for parts of the sources
+#
+# See:
+#   https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+#   https://docs.gitlab.com/user/project/codeowners/reference/
+#
+
+# Default code owners - automatically assigned for reviews
+* @c-jo


### PR DESCRIPTION
# Summary

The CODEOWNERS file will suggest the PR assignees to use automatically. The issue templates offer suggested information that is useful for people to submit.
The PR template offers suggested information that helps to guide users who are submitting code.

Issues will be auto-assigned to c-jo, and PRs will be assigned to the CODEOWNERS referenced users.

# Testing

This has been tested in a number of repositories, and helps to ensure that you get emails when people raise PRs, and that issues show up in the GitHub interface.
